### PR TITLE
Fix debug log string interpolation

### DIFF
--- a/youtube-publish-drafts.js
+++ b/youtube-publish-drafts.js
@@ -181,7 +181,7 @@
         async selectMadeForKids() {
             click(await this.madeForKidsPaperButton());
             await sleep(50);
-            debugLog('"Made for kids" set as ${MADE_FOR_KIDS}');
+            debugLog(`"Made for kids" set as ${MADE_FOR_KIDS}`);
         }
 
         async visibilityStepper() {


### PR DESCRIPTION
Fixed debug log "Made for kids" that was using a wrong string interpolation character.