### PR TITLE
Update youtube-publish-drafts.js

### DIFF
--- a/youtube-publish-drafts.js
+++ b/youtube-publish-drafts.js
@@ -94,7 +94,8 @@
     const VIDEO_ROW_SELECTOR = 'ytcp-video-row';
     const DRAFT_MODAL_SELECTOR = '.style-scope.ytcp-uploads-dialog';
     const DRAFT_BUTTON_SELECTOR = '.edit-draft-button';
-    const MADE_FOR_KIDS_SELECTOR = '#made-for-kids-group';
+    //  const MADE_FOR_KIDS_SELECTOR = '#made-for-kids-group';
+	const VIDEO_MADE_FOR_KIDS_NOT_MFK = '#made-for-kids-group';
     const RADIO_BUTTON_SELECTOR = 'tp-yt-paper-radio-button';
     const VISIBILITY_STEPPER_SELECTOR = '#step-badge-3';
     const VISIBILITY_PAPER_BUTTONS_SELECTOR = 'tp-yt-paper-radio-group';
@@ -239,7 +240,7 @@
             const visibility = await draft.goToVisibility();
             await visibility.setVisibility();
             const dialog = await visibility.save();
-            await dialog.close();
+            // await dialog.close();
             await sleep(100);
         }
     }


### PR DESCRIPTION
Feb-2023 - script 'as-is' does not work,  I only get this to work by making the following changes:

at line 97:
REPLACE:
const MADE_FOR_KIDS_SELECTOR = '#made-for-kids-group';
WITH:
//	const MADE_FOR_KIDS_SELECTOR = '#made-for-kids-group';
	const VIDEO_MADE_FOR_KIDS_NOT_MFK = '#made-for-kids-group';

at line 169:
REPLACE: 
return await waitForElement(MADE_FOR_KIDS_SELECTOR, this.raw);
WITH: 
return await waitForElement(VIDEO_MADE_FOR_KIDS_NOT_MFK, this.raw);

at line 248:
REPLACE:
await dialog.close();
WITH:
//     await dialog.close();

Note: that once it closes the draft screen, it takes approx 10 secs to automatically open the next screen